### PR TITLE
Update to Tower 3.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This role installs Ansible Tower.
 Requirements
 ------------
 
-A license file is needed prior to using and the license path is passed as a variable.
+A license is needed prior to using. License data can then either be put in a file (and path specified in 'license_file_path' parameter) - or passed in as a dict in the 'license_data' parameter.
 
 For the test.yml file to be used, a license.json file needs to be placed in the tests directory.
 
@@ -16,8 +16,31 @@ Role Variables
 - default: blank
 - description: This is a mandatory variable that specifies the path to the license file to be uploaded to Tower after installation.
 
+`license_data`
+- default: blank
+- description: License data
+
+Example:
+```
+tower_config:
+  host: localhost
+  tower_user: admin
+  tower_password: password
+  license_data:
+    company_name: Wiley Enterprises
+    hostname: 02527052e98a69b71706cf5adc872c5e
+    instance_count: 500
+    license_date: 43985743798
+    license_key: dab38cc13e371a4b4e34b2f5cd8755c767cf8cf3864d639d28f868083982f6f1
+    license_type: Enterprise
+    subscription_name: Red Hat Ansible Tower, Premium (500 Managed Nodes)
+    eula_accepted: 1
+```
+
+Note even though 'eula_accepted' is not stricly part of the license, it's needed in the POST 
+
 `tower_version`
-- default: 3.0.3
+- default: 3.2.6
 - description: This specifies the version of tower to be installed.
 
 `admin_password`

--- a/README.md
+++ b/README.md
@@ -28,9 +28,30 @@ Role Variables
 - default: "password"
 - description: This specifies the password for the Redis cache
 
+`postgres_username`
+- default: "awx"
+- description: Username for the PostgreSQL database
+
 `postgres_password`
 - default: "password"
 - description: This specifies the password for the PostgreSQL database
+
+
+`postgres_host`
+- default: ""
+- description: Host for the PostgreSQL database
+
+`postgres_port`
+- default: ""
+- description: Port for the PostgreSQL database
+
+`postgres_database`
+- default: "awx"
+- description: Name for the PostgreSQL database
+
+`rabbitmq_password`
+- default: "password"
+- description: This specifies the password for RabbitMQ
 
 `install_cli`
 - default: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,16 @@
 ---
-# defaults file for tower
-
-tower_version: 3.0.3
+tower_version: 3.2.6
 
 admin_password: password
+
 redis_password: password
+
+postgres_host: ''
+postgres_port: ''
+postgres_database: awx
+postgres_username: awx
 postgres_password: password
+
+rabbitmq_password: password
 
 install_cli: true

--- a/library/tower_config.py
+++ b/library/tower_config.py
@@ -34,6 +34,8 @@ def get_authtoken(module):
 
     resp, info = fetch_url(module, url, method='POST', data=json_data,
                            headers=headers)
+    if not resp and info:
+        raise Exception(info)
     content = json.loads(resp.read())
 
     return content['token']
@@ -50,6 +52,8 @@ def upload_license(module, ul, token):
     ul_json = json.dumps(ul)
     resp, info = fetch_url(module, url, data=ul_json, headers=headers,
                            method='POST')
+    if not resp and info:
+        raise Exception(info)
     output = resp.read()
 
     return info['status']
@@ -87,6 +91,8 @@ def get_license(module, token):
     headers['Authorization'] = "Token {0}".format(token)
 
     resp, info = fetch_url(module, url, headers=headers)
+    if not resp and info:
+        raise Exception(info)
     content = json.loads(resp.read())
 
     return content['license_info']

--- a/library/tower_config.py
+++ b/library/tower_config.py
@@ -76,8 +76,8 @@ def compare_license(ul, tl):
     return 0
 
 
-def get_license_file(license):
-    with open(license) as license_data:
+def get_license_file(license_file_path):
+    with open(license_file_path) as license_data:
         d = json.load(license_data)
     return d
 
@@ -99,8 +99,7 @@ def get_license(module, token):
 
 def tower_license(module, token):
     if module.params['license_file_path']:
-        license_path = module.params['license_file_path']
-        user_license = get_license_file(license_path)
+        user_license = get_license_file(module.params['license_file_path'])
     elif module.params['license_data']:
         user_license = module.params['license_data']
     else:
@@ -131,7 +130,7 @@ def main():
 
     output = {}
 
-    if module.params['license'] or module.params['license_data']:
+    if module.params['license_file_path'] or module.params['license_data']:
         license_msg, license_status = tower_license(module, authtoken)
         output['tower_license'] = {}
         output['tower_license']['msg'] = license_msg

--- a/library/tower_config.py
+++ b/library/tower_config.py
@@ -56,10 +56,13 @@ def upload_license(module, ul, token):
 
 
 def compare_license(ul, tl):
-    compare_list = ['company_name', 'contact_email', 'contact_name',
-                    'hostname', 'instance_count', 'license_date',
-                    'license_key', 'license_type', 'subscription_name',
-                    'trial']
+    compare_list = ['company_name',
+                    'hostname',
+                    'instance_count',
+                    'license_date',
+                    'license_key',
+                    'license_type',
+                    'subscription_name']
 
     for param in compare_list:
         if ul[param] != tl[param]:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,26 +5,31 @@
     src: http://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ tower_version }}.tar.gz
     dest: /tmp
     remote_src: True
+
 - name: Set Passwords for Setup
   template:
     src: inventory.j2
     dest: /tmp/inventory
     mode: 0600
+
 - name: Run Tower Install Script
   become: true
   shell: ./setup.sh -i /tmp/inventory
   args:
     chdir: /tmp/ansible-tower-setup-{{ tower_version }}/
     creates: /etc/tower
+
 - name: Install Pip
   become: true
   yum:
     name: python-pip
+
 - name: Install tower-cli
   become: true
   pip:
     name: ansible-tower-cli
   when: install_cli == True
+
 - name: Configure tower-cli
   become: true
   shell: tower-cli config --global host 127.0.0.1 && tower-cli config --global username admin && tower-cli config --global password {{ admin_password }}

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -1,7 +1,5 @@
-[primary]
+[tower]
 localhost ansible_connection=local
-
-[secondary]
 
 [database]
 
@@ -9,9 +7,21 @@ localhost ansible_connection=local
 admin_password='{{ admin_password }}'
 redis_password='{{ redis_password }}'
 
-pg_host=''
-pg_port=''
-
-pg_database='awx'
-pg_username='awx'
+pg_host='{{ postgres_host }}'
+pg_port='{{ postgres_port }}'
+pg_database='{{ postgres_database }}'
+pg_username='{{ postgres_username }}'
 pg_password='{{ postgres_password }}'
+
+rabbitmq_port=5672
+rabbitmq_vhost=tower
+rabbitmq_username=tower
+rabbitmq_password='{{ rabbitmq_password }}'
+rabbitmq_cookie=cookiemonster
+
+# Needs to be true for fqdns and ip addresses
+rabbitmq_use_long_name=false
+
+# Isolated Tower nodes automatically generate an RSA key for authentication;
+# To disable this behavior, set this value to false
+# isolated_key_generation=true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for tower


### PR DESCRIPTION
- add parameter "license_data" (dict) to avoid license needing to be a file
- update to 3.2.6, required inventory changes
- tower_config module - give better feedback if fails (e.g. missing item in tower-license.json)
- tower_config module - compare_licence remove non-mandatory contact_* fields